### PR TITLE
Add 'Actions' header to committee members table

### DIFF
--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -63,7 +63,7 @@
             <th>Last</th>
             <th>Role</th>
             <th>Department/Affiliation</th>
-            <th></th>
+            <th><span class="sr-only">Actions</span></th>
           </tr>
           {% for cmember in candidate.committee_members.all %}
           <tr>


### PR DESCRIPTION
This allows an otherwise empty header to read as something sensible to screen readers - still blank visually.